### PR TITLE
Add extract command for home/rockyou.tar.gz in grpc-service Dockerfile

### DIFF
--- a/grpc-service/Dockerfile
+++ b/grpc-service/Dockerfile
@@ -2,5 +2,5 @@ FROM openjdk:8
 
 ADD target/grpc-service-1.0-SNAPSHOT.jar /home/app.jar
 ADD rockyou.tar.gz /home
-
+CMD tar xf /home/rockyou.tar.gz /home
 CMD java -Xmx2g -Xms2g -jar /home/app.jar


### PR DESCRIPTION
Add extract command for home/rockyou.tar.gz in grpc-service Dockerfile this is due to an error occur while trying to create PasswordDicReader bean. 